### PR TITLE
Enable git am without git configuration.

### DIFF
--- a/bintrace-qemu/build.sh
+++ b/bintrace-qemu/build.sh
@@ -14,7 +14,7 @@ if [ ! -d $QEMU_DIR ]; then
 	git reset --hard $TAG
 
 	echo "[*] Applying patches"
-	git am $PATCH_DIR/*.patch
+	EMAIL=$(whoami)@localhost git am $PATCH_DIR/*.patch
 
 	echo "[*] Configuring QEMU..."
 	./configure --target-list=x86_64-linux-user --enable-plugins


### PR DESCRIPTION
`git am` fails if the current git directory does not have an email associated with it. This PR sets a temporary email for `git am`.