### PR TITLE
Add pyproject.toml to bintrace-qemu

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,10 +33,16 @@ jobs:
           mkdir -p $WHEELS
           export PIP_FIND_LINKS=$WHEELS
 
+          # Build and install from wheel for tests
           pip install build
           python -m build --outdir $WHEELS
           python -m build --outdir $WHEELS ./bintrace-qemu
           pip install bintrace bintrace-qemu
+
+          # Build in-place for pylint. This is done after the isolated build to
+          # prevent artifacts from polluting the dists
+          # python -m build doesn't appear to support in-place build
+          python setup.py build
 
           echo -e "\nCompiler Cache Stats:"
           ccache -s -c

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,8 +28,16 @@ jobs:
           export PATH="/usr/lib/ccache:$PATH"
           git config --global user.name 'Tester'
           git config --global user.email 'nobody@nowhere'
-          pip install --verbose .
-          pip install --verbose ./bintrace-qemu
+
+          export WHEELS=~/wheels
+          mkdir -p $WHEELS
+          export PIP_FIND_LINKS=$WHEELS
+
+          pip install build
+          python -m build --outdir $WHEELS
+          python -m build --outdir $WHEELS ./bintrace-qemu
+          pip install bintrace bintrace-qemu
+
           echo -e "\nCompiler Cache Stats:"
           ccache -s -c
       - name: Lint

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 __pycache__
 bintrace_native.*.so
 build/
+dist/

--- a/README.md
+++ b/README.md
@@ -7,13 +7,15 @@ bintrace
   * Only intended to be run on Linux, for now. API likely to change.
 
 ```bash
-sudo apt install ninja-build ccache flatbuffers-compiler libflatbuffers-dev
+sudo apt install flatbuffers-compiler libflatbuffers-dev
 git clone https://github.com/mborgerson/bintrace
+pip install build
 cd bintrace
-pip install .                      # install bintrace, for trace analysis
-pip install ./bintrace-qemu        # install bintrace qemu tracer, for trace collection
-bintrace-qemu /usr/bin/uname -a    # produces uname.trace in current dir
-python -m bintrace uname.trace     # print out all events
+python -m build
+pip install dist/*.whl              # install bintrace, for trace analysis
+pip install -f dist ./bintrace-qemu # install bintrace qemu tracer, for trace collection
+bintrace-qemu /usr/bin/uname -a     # produces uname.trace in current dir
+python -m bintrace uname.trace      # print out all events
 ```
 
 Inspired by [qira](https://qira.me/).

--- a/bintrace-qemu/.gitignore
+++ b/bintrace-qemu/.gitignore
@@ -1,3 +1,4 @@
 bintrace-qemu/bin/
 qemu-plugin/libtrace.so
 qemu
+dist/

--- a/bintrace-qemu/MANIFEST.in
+++ b/bintrace-qemu/MANIFEST.in
@@ -1,0 +1,4 @@
+include build.sh
+include qemu-patches/*.patch
+include qemu-plugin/Makefile
+include qemu-plugin/*.cpp

--- a/bintrace-qemu/pyproject.toml
+++ b/bintrace-qemu/pyproject.toml
@@ -2,6 +2,8 @@
 requires = [
     "setuptools>=42",
     "wheel",
+    "cmake",
+    "ninja",
     "bintrace",
 ]
 

--- a/bintrace-qemu/pyproject.toml
+++ b/bintrace-qemu/pyproject.toml
@@ -1,0 +1,8 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel",
+    "bintrace",
+]
+
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
When using a pep517 isolated build this will make sure bintrace is installed in the build environment. However, since bintrace is not on PyPI as of yet, pip still won't know where to find bintrace unless you first build a distributable and make pip aware of it, such as with `-f`.